### PR TITLE
Export chakra ui provider

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clinia-ui/react",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "module": "./dist/index.mjs",

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -6,3 +6,6 @@ export * from "./hooks";
 
 // Icons
 export * from "@chakra-ui/icons";
+
+// Provider
+export { ChakraProvider } from "@chakra-ui/react";


### PR DESCRIPTION
In order to prevent the need from importing `ChakraProvider` directly from `chakra-ui/react` in repos which use this library, it is now exported from `clinia-ui/react`.